### PR TITLE
Fixing highlighting errors

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,8 +18,7 @@ paginate: 10
 exclude: ['README.md', 'Gemfile.lock', 'Gemfile', 'Rakefile']
 
 github_username: WardLin
-highlighter: Pygments
-
+highlighter: rouge
 # Build settings
 markdown: kramdown
 


### PR DESCRIPTION
GitHub Pages does not support other highlighters and will automatically use the default Rouge,so we should change the highlighter value to rouge in our  _config.yml file